### PR TITLE
Add alertmanager spec.alerting.alertmanagers.namespace to prometheus CRD

### DIFF
--- a/prometheus/prometheus.yaml
+++ b/prometheus/prometheus.yaml
@@ -5,9 +5,10 @@ metadata:
 spec:
   alerting:
     alertmanagers:
-    - name: alertmanager-operated
+    - name: app-sre
       port: web
       scheme: http
+      namespace: app-sre-prometheus
   baseImage: quay.io/prometheus/prometheus
   externalLabels:
     cluster: app-sre-dev


### PR DESCRIPTION
Changes:
- Add missing key spec.alerting.alertmanagers.namespace to prometheus CRD YAML
- Change alertmanager name to alertmanager in the same namespace

Fix: https://github.com/app-sre/bookish-dollop/issues/3